### PR TITLE
VP-3367: Rename printers property "SCREEN SIZE" to "LCD Size"

### DIFF
--- a/Setup/ClothingAndElectronics/VirtoCommerce.Catalog.json
+++ b/Setup/ClothingAndElectronics/VirtoCommerce.Catalog.json
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2591b8969319168b1b9eb56d2c2237db33d3760b8e3afb7cf0a2e61c9f1e1c88
-size 80004290
+oid sha256:54ee9afa14cfe6caf4c20532b16f66b88f34adb26cabba808d050cac244b56ac
+size 80004209

--- a/manifest.json
+++ b/manifest.json
@@ -25,7 +25,7 @@
         "name": "Clothing and Electronics",
         "description": "Contains sample data for demo",
         "url": "clothing-and-electronics_3_0_0.zip",
-        "size": "46mb",
+        "size": "63mb",
         "platformVersion": "3.0.0"
     }
 ]


### PR DESCRIPTION
### Problem
Error while indexing products with ElasticSearch provider

### Solution
Rename printers property "SCREEN SIZE" to "LCD Size"

