### PR TITLE
VP-4599: Add permission "storefront:user:view" to roles "org-employee" and "purchasing-agent"

### DIFF
--- a/Setup/ClothingAndElectronics/PlatformEntries.json
+++ b/Setup/ClothingAndElectronics/PlatformEntries.json
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6057dd9942d8739627a44030068a6c40063501029a52eb9b706ed88977465ad3
-size 72839
+oid sha256:f34364a1bd58f281aa1a4bd413235cedf3a1a1ffb602ab4ff4fa1cbf44f3c59d
+size 73645


### PR DESCRIPTION
 For proper work of VP-3977 case we need to extend existed roles "org-employee" and "purchasing-agent" with "storefront:user:view" permission. 